### PR TITLE
Add initial logic of classes searching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ notifications:
   email: false
   slack:
     rooms:
-          - test-automation-tools:CMmRQOwodzTGByyGqAnySHHS#sunshine
+          - test-automation-tools:CMmRQOwodzTGByyGqAnySHHS#sunshine-robots
+
+script: ./test.sh

--- a/build.gradle
+++ b/build.gradle
@@ -10,5 +10,9 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    compileOnly 'org.projectlombok:lombok:1.16.14'
+    testCompile 'junit:junit:4.11'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
+
+defaultTasks 'clean', 'test'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'sunshine'
-
+include 'testng-tests'

--- a/src/main/java/org/sstat/sunshine/Artifact.java
+++ b/src/main/java/org/sstat/sunshine/Artifact.java
@@ -1,0 +1,34 @@
+package org.sstat.sunshine;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+@EqualsAndHashCode
+@ToString(of = {"artifactPath"})
+public final class Artifact {
+
+    private final String fromPath;
+    private final String artifactPath;
+
+    public Artifact(String fromPath, String artifactPath) {
+        this.fromPath = fromPath;
+        this.artifactPath = artifactPath;
+    }
+
+    public Artifact(String relativePath) {
+        this("", relativePath);
+    }
+
+    public String asString() {
+        if (fromPath.isEmpty()) return artifactPath;
+        if (fromPath.equals(artifactPath)) return artifactPath;
+        if (fromPath.endsWith("/")) {
+            return artifactPath.substring(fromPath.length());
+        }
+        return artifactPath.substring(fromPath.length() + 1);
+    }
+}

--- a/src/main/java/org/sstat/sunshine/BaseTestFile.java
+++ b/src/main/java/org/sstat/sunshine/BaseTestFile.java
@@ -1,0 +1,19 @@
+package org.sstat.sunshine;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class BaseTestFile implements TestFile {
+    private final String path;
+
+    public BaseTestFile(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public Class<?> asClass() throws ClassNotFoundException {
+        String className = path.replaceAll("[/\\\\]", ".").replaceFirst("^\\.", "").replace(".class", "");
+        return Class.forName(className);
+    }
+}

--- a/src/main/java/org/sstat/sunshine/BaseTestFiles.java
+++ b/src/main/java/org/sstat/sunshine/BaseTestFiles.java
@@ -1,0 +1,45 @@
+package org.sstat.sunshine;
+
+import org.sstat.sunshine.location.Jar;
+import org.sstat.sunshine.location.Location;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class BaseTestFiles implements TestFiles {
+    private final Location location;
+
+    public BaseTestFiles(Location location) {
+        this.location = location;
+    }
+
+    @Override
+    public List<TestFile> allTests() {
+        return testFiles(location, new ArrayList<>());
+    }
+
+    private List<TestFile> testFiles(Location location, List<TestFile> result) {
+        for (Artifact file : location.files()) {
+            String path = file.asString();
+            if (isClass(path)) {
+                result.add(new BaseTestFile(path));
+            } else if (isJar(path)) {
+                testFiles(new Jar(path), result);
+            }
+        }
+        return result;
+    }
+
+
+    private boolean isClass(String path) {
+        return path.matches(".+\\.class$") && !path.contains("$");
+    }
+
+    private boolean isJar(String path) {
+        return path.endsWith(".jar");
+    }
+}

--- a/src/main/java/org/sstat/sunshine/TestFile.java
+++ b/src/main/java/org/sstat/sunshine/TestFile.java
@@ -1,0 +1,12 @@
+package org.sstat.sunshine;
+
+/**
+ * The interface represents a class with a test (tests).
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public interface TestFile {
+
+    Class<?> asClass() throws ClassNotFoundException;
+}

--- a/src/main/java/org/sstat/sunshine/TestFiles.java
+++ b/src/main/java/org/sstat/sunshine/TestFiles.java
@@ -1,0 +1,14 @@
+package org.sstat.sunshine;
+
+import java.util.List;
+
+/**
+ * The interface represents some test classes.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public interface TestFiles {
+
+    List<TestFile> allTests();
+}

--- a/src/main/java/org/sstat/sunshine/location/Classpath.java
+++ b/src/main/java/org/sstat/sunshine/location/Classpath.java
@@ -1,0 +1,22 @@
+package org.sstat.sunshine.location;
+
+import org.sstat.sunshine.Artifact;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class Classpath implements Location {
+    @Override
+    public List<Artifact> files() {
+        return new CompositeLocation(
+                Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                        .map(Path::new).collect(Collectors.toList())
+        ).files();
+    }
+}

--- a/src/main/java/org/sstat/sunshine/location/CompositeLocation.java
+++ b/src/main/java/org/sstat/sunshine/location/CompositeLocation.java
@@ -1,0 +1,27 @@
+package org.sstat.sunshine.location;
+
+import org.sstat.sunshine.Artifact;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class CompositeLocation implements Location {
+    private final List<Location> locations;
+
+    public CompositeLocation(List<Location> locations) {
+        this.locations = locations;
+    }
+
+    @Override
+    public List<Artifact> files() {
+        List<Artifact> files = new ArrayList<>();
+        for (Location location : locations) {
+            files.addAll(location.files());
+        }
+        return files;
+    }
+}

--- a/src/main/java/org/sstat/sunshine/location/Jar.java
+++ b/src/main/java/org/sstat/sunshine/location/Jar.java
@@ -1,0 +1,38 @@
+package org.sstat.sunshine.location;
+
+import org.sstat.sunshine.Artifact;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class Jar implements Location {
+    private final String jarPath;
+
+    public Jar(String jarPath) {
+        this.jarPath = jarPath;
+    }
+
+    @Override
+    public List<Artifact> files() {
+        try (ZipInputStream zip = new ZipInputStream(new FileInputStream(jarPath))) {
+            List<Artifact> data = new ArrayList<>();
+            for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+                String name = entry.getName();
+                if (!name.endsWith("/")) {
+                    data.add(new Artifact(name));
+                }
+            }
+            return data;
+        } catch (IOException e) {
+            throw new LocationException(e);
+        }
+    }
+}

--- a/src/main/java/org/sstat/sunshine/location/Location.java
+++ b/src/main/java/org/sstat/sunshine/location/Location.java
@@ -1,0 +1,35 @@
+package org.sstat.sunshine.location;
+
+import org.sstat.sunshine.Artifact;
+
+import java.util.List;
+
+/**
+ * The interface declares a place to search tests classes.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public interface Location {
+
+    /**
+     * Returns a list of files paths. Any implementation has to support recursive search by defined place.
+     *
+     * @return a list of paths
+     */
+    List<Artifact> files();
+
+
+    class Fake implements Location {
+        private final List<Artifact> files;
+
+        Fake(List<Artifact> files) {
+            this.files = files;
+        }
+
+        @Override
+        public List<Artifact> files() {
+            return files;
+        }
+    }
+}

--- a/src/main/java/org/sstat/sunshine/location/LocationException.java
+++ b/src/main/java/org/sstat/sunshine/location/LocationException.java
@@ -1,0 +1,20 @@
+package org.sstat.sunshine.location;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class LocationException extends RuntimeException {
+
+    public LocationException(String message) {
+        super(message);
+    }
+
+    public LocationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LocationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/sstat/sunshine/location/Path.java
+++ b/src/main/java/org/sstat/sunshine/location/Path.java
@@ -1,0 +1,56 @@
+package org.sstat.sunshine.location;
+
+import org.sstat.sunshine.Artifact;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class Path implements Location {
+    private final String path;
+
+    public Path(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public List<Artifact> files() {
+        List<Artifact> files = new ArrayList<>();
+        try {
+            Files.walkFileTree(Paths.get(path), new FileVisitor<java.nio.file.Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs) throws IOException {
+                    files.add(new Artifact(path, file.toString()));
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(java.nio.file.Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new LocationException(e);
+        }
+        return files;
+    }
+}

--- a/src/test/java/org/sstat/sunshine/ArtifactTest.java
+++ b/src/test/java/org/sstat/sunshine/ArtifactTest.java
@@ -1,0 +1,60 @@
+package org.sstat.sunshine;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class ArtifactTest {
+
+    @Test
+    public void asStringForParentWithSlashInTheEnd() {
+        MatcherAssert.assertThat(
+                new Artifact("/a/b/", "/a/b/c").asString(),
+                Matchers.equalTo("c")
+        );
+    }
+
+    @Test
+    public void asStringForParentWithoutSlashInTheEnd() {
+        MatcherAssert.assertThat(
+                new Artifact("/a/b", "/a/b/c").asString(),
+                Matchers.equalTo("c")
+        );
+    }
+
+    @Test
+    public void asStringWithoutParent() {
+        MatcherAssert.assertThat(
+                new Artifact("c").asString(),
+                Matchers.equalTo("c")
+        );
+    }
+
+    @Test
+    public void asStringWhenParentIsEqualsToFull() {
+        MatcherAssert.assertThat(
+                new Artifact("/a/b/c", "/a/b/c").asString(),
+                Matchers.equalTo("/a/b/c")
+        );
+    }
+
+    @Test
+    public void asStringForRelativeParentWithSlashInTheEnd() {
+        MatcherAssert.assertThat(
+                new Artifact("a/b/", "a/b/c").asString(),
+                Matchers.equalTo("c")
+        );
+    }
+
+    @Test
+    public void asStringForRelativeParentWithoutSlashInTheEnd() {
+        MatcherAssert.assertThat(
+                new Artifact("a/b", "a/b/c").asString(),
+                Matchers.equalTo("c")
+        );
+    }
+}

--- a/src/test/java/org/sstat/sunshine/BaseTestFileTest.java
+++ b/src/test/java/org/sstat/sunshine/BaseTestFileTest.java
@@ -1,0 +1,26 @@
+package org.sstat.sunshine;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.sstat.sunshine.location.Location;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class BaseTestFileTest {
+
+    @Test(expected = ClassNotFoundException.class)
+    public void asClassWithGhostClass() throws ClassNotFoundException {
+        new BaseTestFile("org/sstat/testng/Test1.class").asClass();
+    }
+
+    @Test
+    public void withRealClass() throws ClassNotFoundException {
+        MatcherAssert.assertThat(
+                new BaseTestFile("org/sstat/sunshine/location/Location.class").asClass(),
+                Matchers.equalTo(Location.class)
+        );
+    }
+}

--- a/src/test/java/org/sstat/sunshine/BaseTestFilesTest.java
+++ b/src/test/java/org/sstat/sunshine/BaseTestFilesTest.java
@@ -1,0 +1,20 @@
+package org.sstat.sunshine;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.sstat.sunshine.location.Jar;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class BaseTestFilesTest {
+    @Test
+    public void allTests() {
+        MatcherAssert.assertThat(
+                new BaseTestFiles(new Jar("src/test/resources/testng-tests-0.1.0.jar")).allTests(),
+                Matchers.not(Matchers.empty())
+        );
+    }
+}

--- a/src/test/java/org/sstat/sunshine/location/ClasspathTest.java
+++ b/src/test/java/org/sstat/sunshine/location/ClasspathTest.java
@@ -1,0 +1,17 @@
+package org.sstat.sunshine.location;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class ClasspathTest {
+
+    @Test
+    public void files() {
+        MatcherAssert.assertThat(new Classpath().files(), Matchers.not(Matchers.empty()));
+    }
+}

--- a/src/test/java/org/sstat/sunshine/location/CompositeLocationTest.java
+++ b/src/test/java/org/sstat/sunshine/location/CompositeLocationTest.java
@@ -1,0 +1,28 @@
+package org.sstat.sunshine.location;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.sstat.sunshine.Artifact;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class CompositeLocationTest {
+    @Test
+    public void files() {
+        List<Location> locations = Arrays.asList(
+                new Location.Fake(Collections.singletonList(new Artifact("ss"))),
+                new Location.Fake(Collections.singletonList(new Artifact("dd")))
+        );
+        MatcherAssert.assertThat(
+                new CompositeLocation(locations).files(),
+                Matchers.hasSize(2)
+        );
+    }
+}

--- a/src/test/java/org/sstat/sunshine/location/JarTest.java
+++ b/src/test/java/org/sstat/sunshine/location/JarTest.java
@@ -1,0 +1,20 @@
+package org.sstat.sunshine.location;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.sstat.sunshine.Artifact;
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class JarTest {
+    @Test
+    public void files() {
+        MatcherAssert.assertThat(
+                new Jar("src/test/resources/testng-tests-0.1.0.jar").files(),
+                Matchers.hasItem(new Artifact("org/sstat/testng/Test1.class"))
+        );
+    }
+}

--- a/src/test/java/org/sstat/sunshine/location/PathTest.java
+++ b/src/test/java/org/sstat/sunshine/location/PathTest.java
@@ -1,0 +1,20 @@
+package org.sstat.sunshine.location;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+
+/**
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class PathTest {
+
+    private static final String RESOURCES = "src/test/resources";
+
+    @Test
+    public void files() {
+        MatcherAssert.assertThat(new Path(RESOURCES).files(), Matchers.hasSize(1));
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+./gradlew -b testng-tests/build.gradle
+./gradlew

--- a/testng-tests/build.gradle
+++ b/testng-tests/build.gradle
@@ -1,0 +1,25 @@
+group 'org.sstat'
+version '0.1.0'
+
+apply plugin: 'java'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'org.testng:testng:6.11'
+}
+
+task copyJar(type: Copy) {
+    from "${buildDir}/libs/testng-tests-${version}.jar"
+    into "${buildDir}/../../src/test/resources"
+}
+
+copyJar.dependsOn(build)
+
+defaultTasks 'clean', 'copyJar'
+
+

--- a/testng-tests/src/main/java/org/sstat/testng/Test1.java
+++ b/testng-tests/src/main/java/org/sstat/testng/Test1.java
@@ -1,0 +1,11 @@
+package org.sstat.testng;
+
+/**
+ * This is an empty class.
+ *
+ * @author Dmytro Serdiuk (dmytro.serdiuk@gmail.com)
+ * @since 16.03.2017
+ */
+public class Test1 {
+
+}


### PR DESCRIPTION
Add new module named 'testng-tests' to provide a jar file with some
TestNG test classes fro unit testing purposes.
Update .travis.yml configuration with relevant commands to run unit
tests.

Add interface and theirs implementation which allows to find Java
classes from specified location:
- classpath
- jar file
- some filesystem path

Add unit tests.

Closes #8